### PR TITLE
Enable TLS Encrpytion

### DIFF
--- a/cmd/lb-api/main.go
+++ b/cmd/lb-api/main.go
@@ -54,14 +54,18 @@ func main() {
 	// Middleware
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
+
+	// Register api with authentication
 	api := e.Group("", middleware.KeyAuthWithConfig(middleware.KeyAuthConfig{
 		Validator: func(key string, c echo.Context) (bool, error) {
 			return subtle.ConstantTimeCompare([]byte(key), []byte(cfg.BearerToken)) == 1, nil
 		},
 	}))
 	generate.RegisterHandlers(api, s)
+
+	// Serve UI
 	e.StaticFS("/ui", echo.MustSubFS(ui, "dist"))
 
 	// Start server
-	e.Logger.Fatal(e.Start(cfg.AdminAddress))
+	e.Logger.Fatal(e.StartTLS(cfg.AdminAddress, cfg.TLS.CertificateFilename, cfg.TLS.KeyFilename))
 }

--- a/pkg/lb-api/config/config.go
+++ b/pkg/lb-api/config/config.go
@@ -8,8 +8,12 @@ import (
 )
 
 type Config struct {
-	AdminAddress         string   `yaml:"admin_address"`
-	BearerToken          string   `yaml:"bearer_token"`
+	AdminAddress string `yaml:"admin_address"`
+	BearerToken  string `yaml:"bearer_token"`
+	TLS          struct {
+		CertificateFilename string `yaml:"certificate_filename"`
+		KeyFilename         string `yaml:"key_filename"`
+	} `yaml:"tls"`
 	DBFilename           string   `yaml:"db_filename"`
 	ConfiguratorFilename string   `yaml:"configurator_filename"`
 	ConfiguratorCommand  []string `yaml:"configurator_command"`


### PR DESCRIPTION
This patch enabled TLS Encrpytion for the communication between the Cloud Provider Manager and the LB API.