### PR TITLE
Update Typo in Cloud Provider Manager Service

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -69,7 +69,7 @@ After=network-online.target
 ExecStart=/src/cloud-provider-manager \
     --cloud-config /etc/cloud-provider-manager/cloud.yaml \
     --kubeconfig /etc/cloud-provider-manager/kubeconfig \
-    --cloud-provider lb-api
+    --cloud-provider lb-api \
     -v 4
 
 [Install]


### PR DESCRIPTION
This patch fixes a Typo in the Cloud Provider Manager Service to properly enable verbose logging.