### PR TITLE
Make LB API TLS Encryption optional

### DIFF
--- a/cmd/lb-api/main.go
+++ b/cmd/lb-api/main.go
@@ -66,6 +66,9 @@ func main() {
 	// Serve UI
 	e.StaticFS("/ui", echo.MustSubFS(ui, "dist"))
 
-	// Start server
+	// Start server with or without TLS
+	if cfg.TLS == nil {
+		e.Logger.Fatal(e.Start(cfg.AdminAddress))
+	}
 	e.Logger.Fatal(e.StartTLS(cfg.AdminAddress, cfg.TLS.CertificateFilename, cfg.TLS.KeyFilename))
 }

--- a/pkg/lb-api/config/config.go
+++ b/pkg/lb-api/config/config.go
@@ -10,7 +10,7 @@ import (
 type Config struct {
 	AdminAddress string `yaml:"admin_address"`
 	BearerToken  string `yaml:"bearer_token"`
-	TLS          struct {
+	TLS          *struct {
 		CertificateFilename string `yaml:"certificate_filename"`
 		KeyFilename         string `yaml:"key_filename"`
 	} `yaml:"tls"`


### PR DESCRIPTION
This Patch makes the TLS encryption baked into the LB API Echo Server optional.